### PR TITLE
update to radis 0.10.3

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -46,6 +46,6 @@ dependencies:
   - vaex    # load HDF5 files
   - habanero  # CrossRef API to retrieve data from doi
   # Specific to radis-lab:
-  - radis>=0.10.1
+  - radis>=0.10.3
   - jupyter-offlinenotebook
   - jupyterlab_hdf


### PR DESCRIPTION
Fixes an important bug when using line-of-sight spectra with mixed equilibrium/non-LTE spectra. See https://github.com/radis/radis/pull/375